### PR TITLE
I have added 2 function wrappers for sanitize.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -25,7 +25,7 @@ assert '$bob' not in new_query['jim']
 assert '$bob' in query['jim']
 
 query = {'jim': {'$bob': 'jones'}}
-new_query = sanitize_query(query) # sanitizes copy of a query and returns it
+new_query = sanitize_query(query) # sanitizes a copy of a query and returns it
 assert '$bob' not in new_query['jim']
 assert '$bob' not in query['jim']
 ----

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -13,9 +13,19 @@ image:https://badge.fury.io/py/MongoSanitizer.svg["PyPI version", link="https://
 
 [source,python]
 ----
-from mongosanitizer.sanitizer import sanitize
+from mongosanitizer.sanitizer import sanitize, sanitize_copy, sanitize_query
 
 query = {'$bob': 'alice'}
-sanitize(query)
+sanitize(query) # sanitizes a query
 assert '$bob' not in query
+
+query = {'jim': {'$bob': 'jones'}}
+new_query = sanitize_copy(query) # sanitizes a query and returns it
+assert '$bob' not in new_query['jim']
+assert '$bob' in query['jim']
+
+query = {'jim': {'$bob': 'jones'}}
+new_query = sanitize_query(query) # sanitizes copy of a query and returns it
+assert '$bob' not in new_query['jim']
+assert '$bob' not in query['jim']
 ----

--- a/mongosanitizer/sanitizer.py
+++ b/mongosanitizer/sanitizer.py
@@ -3,7 +3,36 @@
 """
 
 import sys
+import copy
 
+
+def sanitize_copy(query, deep=True):
+    """Sanitizes a copy of a query by removing any MongoDB functions (keys beginning with the `$` character)
+    Args:
+        query (dict): The query object to sanitize.
+        deep (bool, optional: defailt=True): If true, deep copies a query, else shallow copies a query
+
+    Returns:
+        query (dict): Returns a sanitized query
+    """
+    from sklearn.svm import SVC
+    if deep:
+        query = copy.deepcopy(query)
+    else:
+        query = copy.copy(query)
+    sanitize(query)
+    return query
+
+def sanitize_query(query):
+    """Sanitizes a query by removing any MongoDB functions (keys beginning with the `$` character)
+    Args:
+        query (dict): The query object to sanitize.
+
+    Returns:
+        query (dict): This function mutates a given query and returns that query
+    """
+    sanitize(query)
+    return query
 
 def sanitize(query):
     """Sanitizes a query by removing any MongoDB functions (keys beginning with the `$` character)


### PR DESCRIPTION
Of those function wrappers include sanitize_query which functions the same as sanitize but also returns that query. 
Another is sanitize_copy which which is returns a sanitized version of a query without mutating the original. It works by copying the query passed into it and then mutates it. By default sanitize_copy uses a deep copy but you can also use a shallow copy instead.